### PR TITLE
fixed issue of joystick disposing without properly resetting actions

### DIFF
--- a/addons/joystick_addon/joystick.gd
+++ b/addons/joystick_addon/joystick.gd
@@ -81,3 +81,6 @@ func reset_dir():
 	Input.action_release(down_input)
 	Input.action_release(left_input)
 	Input.action_release(right_input)
+
+func exit_tree():
+	reset_dir()

--- a/addons/joystick_addon/joystick.gd
+++ b/addons/joystick_addon/joystick.gd
@@ -82,5 +82,5 @@ func reset_dir():
 	Input.action_release(left_input)
 	Input.action_release(right_input)
 
-func exit_tree():
+func _exit_tree():
 	reset_dir()


### PR DESCRIPTION
Under some circumstances, the joystick was not releasing the actions pressed before disposing, causing actions to "stick". I added an _exit_tree() override to joystick.gd that calls the action reset function.